### PR TITLE
bug: [회원가입] 약관동의, 닉네임, 최애빵스타일 등록 시 화면 size 작아지는 이슈

### DIFF
--- a/breadgood_app/lib/modules/signup/screens/bread_style.dart
+++ b/breadgood_app/lib/modules/signup/screens/bread_style.dart
@@ -33,14 +33,13 @@ class BreadStyle extends GetView<SignUpController> {
   GridTile getGridTile(int index) {
     return GridTile(
         child: GestureDetector(
-      child: Container(
-          decoration: new BoxDecoration(
-            borderRadius: new BorderRadius.circular(16.0),
-            color: controller.bread_style.value[index].check
-                ? null
-                : THEME.GRAY_244,
-            image: (controller.bread_style.value[index].check)
-                ? DecorationImage(
+          child: Container(
+              decoration: new BoxDecoration(
+                borderRadius: new BorderRadius.circular(16.0),
+                color: controller.bread_style.value[index].check
+                    ? null : THEME.GRAY_244,
+                image: (controller.bread_style.value[index].check)
+                    ? DecorationImage(
                     // image:SvgPicture.asset(
                     //     controller.bread_style.value[index].profileImgUrl,
                     //     semanticsLabel: 'Acme Logo'
@@ -48,42 +47,40 @@ class BreadStyle extends GetView<SignUpController> {
                     // image:Image.asset("asset/images/icon/map/focus_bread.png"),
                     image: NetworkImage(
                         controller.bread_style.value[index].imgUrl),
-                    fit: BoxFit.cover,
-                  )
-                : null,
-          ),
-          padding: EdgeInsets.all(10),
-          // width:155,
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            children: [
-              Expanded(
-                  child: Align(
-                      alignment: Alignment.topLeft,
-                      child: CircleCheckBox(
-                          text: "${controller.bread_style.value[index].name}",
-                          circle_size: 2,
-                          icon_size: 14,
-                          font_size: 16,
-                          line_height: 1.4,
-                          false_color: controller.false_color,
-                          true_color: THEME.MAIN,
-                          isClick: controller.bread_style.value[index].check))),
-              Expanded(
-                  child: Align(
-                alignment: Alignment.topLeft,
-                child: Text(
-                  "${controller.bread_style.value[index].content}",
-                  textAlign: TextAlign.left,
-                  style: TextStyle(fontSize: 12),
-                ),
-              ))
-            ],
-          )),
-      onTap: () {
-        controller.setBreadStyle(index);
-      },
-    ));
+                    fit: BoxFit.cover,)
+                    : null,
+              ),
+              padding: EdgeInsets.all(10),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [
+                  Expanded(
+                      child: Align(
+                          alignment: Alignment.topLeft,
+                          child: CircleCheckBox(
+                              text: "${controller.bread_style.value[index].name}",
+                              circle_size: 2,
+                              icon_size: 14,
+                              font_size: 16,
+                              line_height: 1.4,
+                              false_color: controller.false_color,
+                              true_color: THEME.MAIN,
+                              isClick: controller.bread_style.value[index].check))),
+                  Expanded(
+                      child: Align(
+                        alignment: Alignment.topLeft,
+                        child: Text(
+                          "${controller.bread_style.value[index].content}",
+                          textAlign: TextAlign.left,
+                          style: TextStyle(fontSize: 12),
+                        ),
+                      ))
+                ],
+              )),
+          onTap: () {
+            controller.setBreadStyle(index);
+            },
+        ));
   }
 
   @override
@@ -104,22 +101,22 @@ class BreadStyle extends GetView<SignUpController> {
                           children: [
                             Expanded(
                                 child: Row(
-                              children: [
-                                Text('최애빵',
-                                    style: TextStyle(
-                                        color: THEME.MAIN,
-                                        fontSize: 26,
-                                        fontWeight: FontWeight.w800,
-                                        fontFamily: 'NanumSquareRoundEB')),
-                                Text(
-                                  ' 스타일을 알려주세요!',
-                                  style: TextStyle(
-                                      fontSize: 26,
-                                      fontWeight: FontWeight.w800,
-                                      fontFamily: 'NanumSquareRoundEB'),
-                                )
-                              ],
-                            )),
+                                  children: [
+                                    Text('최애빵',
+                                        style: TextStyle(
+                                            color: THEME.MAIN,
+                                            fontSize: 26,
+                                            fontWeight: FontWeight.w800,
+                                            fontFamily: 'NanumSquareRoundEB')),
+                                    Text(
+                                      ' 스타일을 알려주세요!',
+                                      style: TextStyle(
+                                          fontSize: 26,
+                                          fontWeight: FontWeight.w800,
+                                          fontFamily: 'NanumSquareRoundEB'),
+                                    )
+                                  ],
+                                )),
                           ],
                         )),
                     Container(

--- a/breadgood_app/lib/modules/signup/screens/bread_style.dart
+++ b/breadgood_app/lib/modules/signup/screens/bread_style.dart
@@ -33,135 +33,129 @@ class BreadStyle extends GetView<SignUpController> {
   GridTile getGridTile(int index) {
     return GridTile(
         child: GestureDetector(
-          child: Container(
-              decoration: new BoxDecoration(
-                borderRadius: new BorderRadius.circular(16.0),
-                color: controller.bread_style.value[index].check ? null : THEME
-                    .GRAY_244,
-                image:
-                (controller.bread_style.value[index].check) ?
-                DecorationImage(
+      child: Container(
+          decoration: new BoxDecoration(
+            borderRadius: new BorderRadius.circular(16.0),
+            color: controller.bread_style.value[index].check
+                ? null
+                : THEME.GRAY_244,
+            image: (controller.bread_style.value[index].check)
+                ? DecorationImage(
                     // image:SvgPicture.asset(
                     //     controller.bread_style.value[index].profileImgUrl,
                     //     semanticsLabel: 'Acme Logo'
                     // ),
-                  // image:Image.asset("asset/images/icon/map/focus_bread.png"),
-                  image: NetworkImage(
-                      controller.bread_style.value[index].imgUrl),
-                  fit: BoxFit.cover,
-                ) : null,
-              ),
-              padding: EdgeInsets.all(10),
-              // width:155,
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                children: [
-                  Expanded(
-                      child:
-                      Align(
-                          alignment: Alignment.topLeft,
-                          child: CircleCheckBox(
-                              text: "${controller.bread_style.value[index]
-                                  .name}",
-                              circle_size: 2,
-                              icon_size: 14,
-                              font_size: 16,
-                              line_height: 1.4,
-                              false_color: controller.false_color,
-                              true_color: THEME.MAIN,
-                              isClick: controller.bread_style.value[index].check)
-                      )),
-                  Expanded(
-                      child: Align(
-                        alignment: Alignment.topLeft,
-                        child: Text(
-                          "${controller.bread_style.value[index].content}",
-                          textAlign: TextAlign.left,
-                          style: TextStyle(fontSize: 12),
-                        ),
-                      )
-
+                    // image:Image.asset("asset/images/icon/map/focus_bread.png"),
+                    image: NetworkImage(
+                        controller.bread_style.value[index].imgUrl),
+                    fit: BoxFit.cover,
                   )
-                ],
-              )
+                : null,
           ),
-          onTap: () {
-            controller.setBreadStyle(index);
-          },
-        ));
+          padding: EdgeInsets.all(10),
+          // width:155,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: [
+              Expanded(
+                  child: Align(
+                      alignment: Alignment.topLeft,
+                      child: CircleCheckBox(
+                          text: "${controller.bread_style.value[index].name}",
+                          circle_size: 2,
+                          icon_size: 14,
+                          font_size: 16,
+                          line_height: 1.4,
+                          false_color: controller.false_color,
+                          true_color: THEME.MAIN,
+                          isClick: controller.bread_style.value[index].check))),
+              Expanded(
+                  child: Align(
+                alignment: Alignment.topLeft,
+                child: Text(
+                  "${controller.bread_style.value[index].content}",
+                  textAlign: TextAlign.left,
+                  style: TextStyle(fontSize: 12),
+                ),
+              ))
+            ],
+          )),
+      onTap: () {
+        controller.setBreadStyle(index);
+      },
+    ));
   }
 
   @override
   Widget build(BuildContext context) {
     final controller = Get.put(SignUpController());
-    return SafeArea(
-        child: Scaffold(
-          appBar: AlreadyRegisteredBakeryAppbar(),
-          body: SingleChildScrollView(
-              child: Container(
-                  margin: EdgeInsets.only(top: 42, left: 30, right: 30),
-                  child: Column(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: <Widget>[
-                        Container(
-                            margin: EdgeInsets.only(top: 5),
-                            child: Row(
+    return Scaffold(
+      appBar: AlreadyRegisteredBakeryAppbar(),
+      body: SingleChildScrollView(
+          child: Container(
+              margin: EdgeInsets.only(top: 42, left: 30, right: 30),
+              child: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    Container(
+                        margin: EdgeInsets.only(top: 5),
+                        child: Row(
+                          children: [
+                            Expanded(
+                                child: Row(
                               children: [
-                                Expanded(
-                                    child: Row(
-                                      children: [
-                                        Text('최애빵',
-                                            style: TextStyle(
-                                                color: THEME.MAIN,
-                                                fontSize: 26,
-                                                fontWeight: FontWeight.w800,
-                                                fontFamily: 'NanumSquareRoundEB')),
-                                        Text(
-                                          ' 스타일을 알려주세요!',
-                                          style: TextStyle(
-                                              fontSize: 26,
-                                              fontWeight: FontWeight.w800,
-                                              fontFamily: 'NanumSquareRoundEB'),
-                                        )
-                                      ],
-                                    )),
+                                Text('최애빵',
+                                    style: TextStyle(
+                                        color: THEME.MAIN,
+                                        fontSize: 26,
+                                        fontWeight: FontWeight.w800,
+                                        fontFamily: 'NanumSquareRoundEB')),
+                                Text(
+                                  ' 스타일을 알려주세요!',
+                                  style: TextStyle(
+                                      fontSize: 26,
+                                      fontWeight: FontWeight.w800,
+                                      fontFamily: 'NanumSquareRoundEB'),
+                                )
                               ],
                             )),
-                        Container(
-                            margin: EdgeInsets.only(top: 14, bottom: 48),
-                            child: Row(
-                              children: [
-                                Text('언제든 수정 가능하니 고민하지 마세요!',
-                                    style: TextStyle(fontSize: 16, height: 0.8))
-                              ],
-                            )),
-                        Padding(
-                          padding: EdgeInsets.only(left: 0),
-                          child: Text('중복 선택 불가',
-                              style: TextStyle(
-                                fontSize: 12.0,
-                                color: Colors.grey,
-                              )),
-                        ),
-                        // BreadStylePage(0),
-                        Obx(() {
-                          return _createBody();
-                        }),
-                        Container(
-                            alignment: Alignment(0.0, 1.0),
-                            margin: EdgeInsets.only(top: 88, bottom: 66),
-                            child: Obx(() {
-                              return ShapeBlueButton(
-                                text: '빵긋 시작하기!',
-                                is_able: controller.check_bread_style.value,
-                                successActions: () {
-                                  controller.signUp();
-                                },
-                              );
-                            }))
-                      ]))),
-        ));
+                          ],
+                        )),
+                    Container(
+                        margin: EdgeInsets.only(top: 14, bottom: 48),
+                        child: Row(
+                          children: [
+                            Text('언제든 수정 가능하니 고민하지 마세요!',
+                                style: TextStyle(fontSize: 16, height: 0.8))
+                          ],
+                        )),
+                    Padding(
+                      padding: EdgeInsets.only(left: 0),
+                      child: Text('중복 선택 불가',
+                          style: TextStyle(
+                            fontSize: 12.0,
+                            color: Colors.grey,
+                          )),
+                    ),
+                    // BreadStylePage(0),
+                    Obx(() {
+                      return _createBody();
+                    }),
+                    Container(
+                        alignment: Alignment(0.0, 1.0),
+                        margin: EdgeInsets.only(top: 88, bottom: 66),
+                        child: Obx(() {
+                          return ShapeBlueButton(
+                            text: '빵긋 시작하기!',
+                            is_able: controller.check_bread_style.value,
+                            successActions: () {
+                              controller.signUp();
+                            },
+                          );
+                        }))
+                  ]))),
+    );
   }
 
   Color checkingBorder(is_check, true_color, false_color) {

--- a/breadgood_app/lib/modules/signup/screens/nick_name.dart
+++ b/breadgood_app/lib/modules/signup/screens/nick_name.dart
@@ -16,149 +16,145 @@ class NickName extends GetView<SignUpController> {
     final controller = Get.put(SignUpController());
     Timer _debounce;
     final _formKey = new GlobalKey<FormState>();
-    return SafeArea(
-        child: Scaffold(
-          appBar: AlreadyRegisteredBakeryAppbar(),
-          body: SingleChildScrollView(
-              child: Container(
-                  margin: EdgeInsets.only(top: 42, left: 30, right: 30),
-                  child: Column(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: <Widget>[
-                        Container(
-                            child: Row(
+    return Scaffold(
+      appBar: AlreadyRegisteredBakeryAppbar(),
+      body: SingleChildScrollView(
+          child: Container(
+              margin: EdgeInsets.only(top: 42, left: 30, right: 30),
+              child: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    Container(
+                        child: Row(
+                      children: [
+                        Expanded(
+                            child: Text(
+                          '빵긋에서 사용할',
+                          style: TextStyle(
+                              fontSize: 26,
+                              fontWeight: FontWeight.w800,
+                              fontFamily: 'NanumSquareRoundEB'),
+                        )),
+                      ],
+                    )),
+                    Container(
+                        margin: EdgeInsets.only(top: 5),
+                        child: Row(
+                          children: [
+                            Expanded(
+                                child: Row(
                               children: [
-                                Expanded(
-                                    child: Text(
-                                      '빵긋에서 사용할',
-                                      style: TextStyle(
-                                          fontSize: 26,
-                                          fontWeight: FontWeight.w800,
-                                          fontFamily: 'NanumSquareRoundEB'),
-                                    )),
+                                Text('별명',
+                                    style: TextStyle(
+                                        color: THEME.MAIN,
+                                        fontSize: 26,
+                                        fontWeight: FontWeight.w800,
+                                        fontFamily: 'NanumSquareRoundEB')),
+                                Text(
+                                  '을 입력해주세요!',
+                                  style: TextStyle(
+                                      fontSize: 26,
+                                      fontWeight: FontWeight.w800,
+                                      fontFamily: 'NanumSquareRoundEB'),
+                                )
                               ],
                             )),
-                        Container(
-                            margin: EdgeInsets.only(top: 5),
-                            child: Row(
-                              children: [
-                                Expanded(
-                                    child: Row(
-                                      children: [
-                                        Text('별명',
-                                            style: TextStyle(
-                                                color: THEME.MAIN,
-                                                fontSize: 26,
-                                                fontWeight: FontWeight.w800,
-                                                fontFamily: 'NanumSquareRoundEB')),
-                                        Text(
-                                          '을 입력해주세요!',
-                                          style: TextStyle(
-                                              fontSize: 26,
-                                              fontWeight: FontWeight.w800,
-                                              fontFamily: 'NanumSquareRoundEB'),
-                                        )
-                                      ],
-                                    )),
-                              ],
-                            )),
-                        Container(
-                            margin: EdgeInsets.only(top: 14, bottom: 48),
-                            child: Row(
-                              children: [
-                                Text('언제든 수정 가능하니 고민하지 마세요!',
-                                    style: TextStyle(fontSize: 16, height: 0.8))
-                              ],
-                            )),
-                        Padding(
-                          padding: EdgeInsets.only(left: 0),
-                          child: Text('최대 7글자, 숫자/특수문자/띄어쓰기 불가',
-                              style: TextStyle(
-                                fontSize: 12.0,
-                                color: Colors.grey,
-                              )),
+                          ],
+                        )),
+                    Container(
+                        margin: EdgeInsets.only(top: 14, bottom: 48),
+                        child: Row(
+                          children: [
+                            Text('언제든 수정 가능하니 고민하지 마세요!',
+                                style: TextStyle(fontSize: 16, height: 0.8))
+                          ],
+                        )),
+                    Padding(
+                      padding: EdgeInsets.only(left: 0),
+                      child: Text('최대 7글자, 숫자/특수문자/띄어쓰기 불가',
+                          style: TextStyle(
+                            fontSize: 12.0,
+                            color: Colors.grey,
+                          )),
+                    ),
+                    Padding(
+                        padding: EdgeInsets.only(
+                          top: 0,
+                          left: 0,
+                          right: 0,
                         ),
-                        Padding(
-                            padding: EdgeInsets.only(
-                              top: 0,
-                              left: 0,
-                              right: 0,
-                            ),
-                            child: Obx(() {
-                              return TextFormField(
-                                onChanged: (text) {
-                                  if (controller.validationNickName(text)) {
-                                    if (_debounce?.isActive ?? false) _debounce
-                                        .cancel();
-                                    _debounce =
-                                        Timer(const Duration(
-                                            milliseconds: 250), () {
-                                          controller.duplicatedNickName(text);
-                                        });
-                                  }
-                                },
-                                autofocus: true,
-                                style: TextStyle(fontSize: 16.0),
-                                cursorColor: THEME.GRAY_177,
-                                decoration: InputDecoration(
-                                  errorText: controller.error.value != ''
-                                      ? controller.error.value
-                                      : null,
-                                  hintText: "ex) 빵긋원정대",
-                                  hintStyle:
-                                  TextStyle(
-                                      fontSize: 16.0, color: THEME.GRAY_177),
-                                  border: new UnderlineInputBorder(
-                                      borderSide: new BorderSide(
-                                          color: THEME.GRAY_177, width: 1.0)),
-                                  contentPadding:
+                        child: Obx(() {
+                          return TextFormField(
+                            onChanged: (text) {
+                              if (controller.validationNickName(text)) {
+                                if (_debounce?.isActive ?? false)
+                                  _debounce.cancel();
+                                _debounce = Timer(
+                                    const Duration(milliseconds: 250), () {
+                                  controller.duplicatedNickName(text);
+                                });
+                              }
+                            },
+                            autofocus: true,
+                            style: TextStyle(fontSize: 16.0),
+                            cursorColor: THEME.GRAY_177,
+                            decoration: InputDecoration(
+                              errorText: controller.error.value != ''
+                                  ? controller.error.value
+                                  : null,
+                              hintText: "ex) 빵긋원정대",
+                              hintStyle: TextStyle(
+                                  fontSize: 16.0, color: THEME.GRAY_177),
+                              border: new UnderlineInputBorder(
+                                  borderSide: new BorderSide(
+                                      color: THEME.GRAY_177, width: 1.0)),
+                              contentPadding:
                                   EdgeInsets.only(top: 10.0, bottom: 0.0),
-                                  focusedBorder: UnderlineInputBorder(
-                                    borderSide: const BorderSide(
-                                        color: THEME.GRAY_177, width: 1.0),
-                                  ),
-                                ),
-                                inputFormatters: [
-                                  FilteringTextInputFormatter.deny(RegExp(
-                                      r'^[_\-=@,\.;^]+$')),
-                                  FilteringTextInputFormatter.allow(RegExp(
-                                      '[A-z|ㄱ-ㅎ|ㅏ-ㅣ|가-힣]')),
-                                ],
-                              );
-                            })
-                        ),
-                        Obx(() {
-                          return Padding(
-                              padding: EdgeInsets.only(
-                                top: 5.0,
+                              focusedBorder: UnderlineInputBorder(
+                                borderSide: const BorderSide(
+                                    color: THEME.GRAY_177, width: 1.0),
                               ),
-                              child:
-                              (controller.check_name.value &&
+                            ),
+                            inputFormatters: [
+                              FilteringTextInputFormatter.deny(
+                                  RegExp(r'^[_\-=@,\.;^]+$')),
+                              FilteringTextInputFormatter.allow(
+                                  RegExp('[A-z|ㄱ-ㅎ|ㅏ-ㅣ|가-힣]')),
+                            ],
+                          );
+                        })),
+                    Obx(() {
+                      return Padding(
+                          padding: EdgeInsets.only(
+                            top: 5.0,
+                          ),
+                          child: (controller.check_name.value &&
                                   !controller.is_duplicate_name.value &&
                                   controller.error.value == '')
-                                  ?
-                              Text('사용 가능한 별명이예요!',
+                              ? Text('사용 가능한 별명이예요!',
                                   style: TextStyle(
                                     color: THEME.MAIN,
                                     fontSize: 12.0,
-                                  )) : null
+                                  ))
+                              : null);
+                    }),
+                    Container(
+                        alignment: Alignment(0.0, 1.0),
+                        margin: EdgeInsets.only(top: 88, bottom: 66),
+                        child: Obx(() {
+                          return ShapeBlueButton(
+                            text: '다음 단계로 이동',
+                            is_able: controller.check_name.value &&
+                                !controller.is_duplicate_name.value &&
+                                controller.error.value == '',
+                            successActions: () {
+                              controller.setNickName();
+                              Get.toNamed('/signup/breadstyle');
+                            },
                           );
-                        }),
-                        Container(
-                            alignment: Alignment(0.0, 1.0),
-                            margin: EdgeInsets.only(top: 88, bottom: 66),
-                            child: Obx(() {
-                              return ShapeBlueButton(
-                                  text: '다음 단계로 이동',
-                                  is_able: controller.check_name.value&&!controller.is_duplicate_name
-                                      .value && controller.error.value == '',
-                                  successActions: (){
-                                    controller.setNickName();
-                                    Get.toNamed('/signup/breadstyle');
-                                  },);
-                            }))
-                      ]))),
-        ));
+                        }))
+                  ]))),
+    );
   }
 }

--- a/breadgood_app/lib/modules/signup/screens/policy.dart
+++ b/breadgood_app/lib/modules/signup/screens/policy.dart
@@ -27,136 +27,128 @@ class AgreePolicyAppbar extends DefaultAppBar {
 class AgreePolicy extends GetView<SignUpController> {
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-        child: Scaffold(
-            appBar: AgreePolicyAppbar(),
-            body: SingleChildScrollView(
-              child: Container(
-                margin: EdgeInsets.only(top: 42, left: 30, right: 30),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: <Widget>[
-                    Column(children: [
-                      Container(
-                        margin: EdgeInsets.only(bottom: 16),
-                        child: //전체 체크 박스
-                            Column(
+    return Scaffold(
+        appBar: AgreePolicyAppbar(),
+        body: SingleChildScrollView(
+          child: Container(
+            margin: EdgeInsets.only(top: 42, left: 30, right: 30),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                Column(children: [
+                  Container(
+                    margin: EdgeInsets.only(bottom: 16),
+                    child: //전체 체크 박스
+                        Column(
+                      children: [
+                        Container(
+                            child: Row(
                           children: [
-                            Container(
-                                child: Row(
+                            Text(
+                              '이용약관 동의',
+                              style: TextStyle(
+                                  fontSize: 26,
+                                  fontWeight: FontWeight.w800,
+                                  fontFamily: 'NanumSquareRoundEB'),
+                            )
+                          ],
+                        )),
+                        Container(
+                            margin: EdgeInsets.only(top: 14, bottom: 36),
+                            child: Row(
                               children: [
-                                Text(
-                                  '이용약관 동의',
-                                  style: TextStyle(
-                                      fontSize: 26,
-                                      fontWeight: FontWeight.w800,
-                                      fontFamily: 'NanumSquareRoundEB'),
-                                )
+                                Text('빵긋을 이용하기 위해 약관에 동의해주세요',
+                                    style: TextStyle(fontSize: 16, height: 0.8))
                               ],
                             )),
-                            Container(
-                                margin: EdgeInsets.only(top: 14, bottom: 36),
-                                child: Row(
-                                  children: [
-                                    Text('빵긋을 이용하기 위해 약관에 동의해주세요',
-                                        style: TextStyle(
-                                            fontSize: 16, height: 0.8))
-                                  ],
-                                )),
-                          ],
-                        ),
-                      ),
-                      //세부 체크박스
-                      Column(
-                        children: [
-                          Container(
-                              margin: EdgeInsets.only(bottom: 36),
-                              child: Column(
-                                children: [
-                                  Obx(
-                                    () => ListView.builder(
-                                      physics:
-                                          const NeverScrollableScrollPhysics(),
-                                          shrinkWrap: true,
-                                          itemCount: controller.models.value.length,
-                                          itemBuilder:
-                                          (BuildContext context, int index) {
-                                        return
-                                          GestureDetector(
-                                          child: PolicyButtons(
-                                              text:
-                                                  "${controller.models.value[index].name}",
-                                              circle_size: 2,
-                                              icon_size: 14,
-                                              font_size: 14,
-                                              line_height: 1.4,
-                                              false_color:
-                                                  controller.false_color,
-                                              true_color: controller.true_color,
-                                              isClick: controller
-                                                  .models.value[index].check,
-                                              index:index
-                                          ),
-                                          onTap: () {
-                                            controller.clickCheck(index);
-                                            controller
-                                                .isAllCheckAtclickCheck(index);
-                                          },
-                                        );
+                      ],
+                    ),
+                  ),
+                  //세부 체크박스
+                  Column(
+                    children: [
+                      Container(
+                          margin: EdgeInsets.only(bottom: 36),
+                          child: Column(
+                            children: [
+                              Obx(
+                                () => ListView.builder(
+                                  physics: const NeverScrollableScrollPhysics(),
+                                  shrinkWrap: true,
+                                  itemCount: controller.models.value.length,
+                                  itemBuilder:
+                                      (BuildContext context, int index) {
+                                    return GestureDetector(
+                                      child: PolicyButtons(
+                                          text:
+                                              "${controller.models.value[index].name}",
+                                          circle_size: 2,
+                                          icon_size: 14,
+                                          font_size: 14,
+                                          line_height: 1.4,
+                                          false_color: controller.false_color,
+                                          true_color: controller.true_color,
+                                          isClick: controller
+                                              .models.value[index].check,
+                                          index: index),
+                                      onTap: () {
+                                        controller.clickCheck(index);
+                                        controller
+                                            .isAllCheckAtclickCheck(index);
                                       },
-                                    ),
-                                  )
-                                ],
-                              )),
-                          Obx((){
-                            return GestureDetector(
-                                child: Container(
-                                    padding: EdgeInsets.only(
-                                        top: 15, bottom: 15, left: 62),
-                                    decoration: BoxDecoration(
-                                        borderRadius: BorderRadius.circular(50),
-                                        border: Border.all(
-                                            color: checkingBorder(
-                                                controller.all_check.value,
-                                                controller.true_color,
-                                                Colors.white)),
-                                        color: THEME.GRAY_244),
-                                    child:
-                                    CircleCheckBox(
-                                        text: '위 약관에 모두 동의합니다.',
-                                        circle_size: 2,
-                                        icon_size: 14,
-                                        font_size: 14,
-                                        line_height: 1.4,
-                                        false_color: controller.false_color,
-                                        true_color: controller.true_color,
-                                        isClick: controller.all_check.value)),
-                                onTap: () {
-                                  controller.clickAllCheck();
-                                  // isAllChecking();
-                                });
-                          }),
-                        ],
-                      ),
-                    ]),
-                    Container(
-                      alignment: Alignment(0.0, 1.0),
-                      margin: EdgeInsets.only(top: 180, bottom: 66),
-                      child: Obx((){
-                        return ShapeBlueButton(
-                            text: '다음 단계로 이동', is_able: controller.all_check.value,
-                            successActions: (){
-                              Get.toNamed('/signup/nickname');
+                                    );
+                                  },
+                                ),
+                              )
+                            ],
+                          )),
+                      Obx(() {
+                        return GestureDetector(
+                            child: Container(
+                                padding: EdgeInsets.only(
+                                    top: 15, bottom: 15, left: 62),
+                                decoration: BoxDecoration(
+                                    borderRadius: BorderRadius.circular(50),
+                                    border: Border.all(
+                                        color: checkingBorder(
+                                            controller.all_check.value,
+                                            controller.true_color,
+                                            Colors.white)),
+                                    color: THEME.GRAY_244),
+                                child: CircleCheckBox(
+                                    text: '위 약관에 모두 동의합니다.',
+                                    circle_size: 2,
+                                    icon_size: 14,
+                                    font_size: 14,
+                                    line_height: 1.4,
+                                    false_color: controller.false_color,
+                                    true_color: controller.true_color,
+                                    isClick: controller.all_check.value)),
+                            onTap: () {
+                              controller.clickAllCheck();
+                              // isAllChecking();
                             });
-                      })
-                    )
-                  ],
-                ),
-              ),
-            )));
+                      }),
+                    ],
+                  ),
+                ]),
+                Container(
+                    alignment: Alignment(0.0, 1.0),
+                    margin: EdgeInsets.only(top: 180, bottom: 66),
+                    child: Obx(() {
+                      return ShapeBlueButton(
+                          text: '다음 단계로 이동',
+                          is_able: controller.all_check.value,
+                          successActions: () {
+                            Get.toNamed('/signup/nickname');
+                          });
+                    }))
+              ],
+            ),
+          ),
+        ));
   }
-
 
   Color checkingBorder(is_check, true_color, false_color) {
     return is_check ? controller.true_color : controller.false_color;


### PR DESCRIPTION
### 요약
회원 가입 과정에서 1.약관동의, 2. 닉네임 입력, 3. 최애빵스타일 선택의 화면 size 작아지는 이슈
### 작업내역
"SafeArea" 라는 widget 이 적용되어있어서 명시하지 않은 padding 이 추가되는 것이 문제였음.
모든 화면에 전체적으로 "SafeArea" 라는 Widget 이 적용되어있지는 않으므로, 여기에서도 삭제함.
### 작성자의 고민
"SafeArea" 라는 Widget 은 기기 별로 서로 다른 StatusBar 영역 등 차이에 영향 받지 않는 디자인을 할 수 있도록 도와주는 Widget 으로,
해당 Widget 적용된 상태에서 디자인을 가미한다면 기기별 차이를 고려하지 않아도 문제 없는 디자인을 할 수 있다고하는데,
해당 Widget 을 사용하면 디자이너의 의도와 다르게 화면 사이즈가 작아지고, 의도치않은 padding 으로 위아래에 검은 영역이 생겨버림.
하지만 기기별로 테스트해보지 않아도 디자인상 문제가 없을것이라는 장점이 있어서 두 가지 trade off 중에 고민함.
디자이너의 의도가 더 중요하다고 생각하여 해당 widget 을 삭제하는 것으로 결정함.