### PR TITLE
최초등록자'닉네임'pick으로 빵집 카드 정보와 동일하게 수정

### DIFF
--- a/breadgood-server/src/main/java/com/bside/breadgood/common/vo/ImageUrl.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/common/vo/ImageUrl.java
@@ -1,0 +1,44 @@
+package com.bside.breadgood.common.vo;
+
+import com.bside.breadgood.common.exception.EmptyException;
+import com.bside.breadgood.util.FileUtils;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.util.regex.Pattern;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ImageUrl {
+
+    private static final Pattern URL_PATTERN = Pattern.compile("^(?:https?:\\/\\/)?(?:www\\.)?[a-zA-Z0-9./]+$");
+
+    @Column
+    private String imgUrl;
+
+    private ImageUrl(String imgUrl) {
+        validate(imgUrl);
+        this.imgUrl = imgUrl;
+    }
+
+    private void validate(String imgUrl) {
+        if (!StringUtils.hasText(imgUrl)) {
+            throw new EmptyException("이미지 URL 이 빈값입니다. ");
+        }
+
+        if (URL_PATTERN.matcher(imgUrl).matches()) {
+            throw new IllegalArgumentException("유효하지 않은 URL 입니다.");
+        }
+
+        FileUtils.validateFileExtension(imgUrl);
+    }
+
+    public static ImageUrl from(String imgUrl) {
+        return new ImageUrl(imgUrl);
+    }
+}

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/bakery/application/BakeryService.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/bakery/application/BakeryService.java
@@ -44,7 +44,7 @@ import java.util.stream.Stream;
 @Service
 @RequiredArgsConstructor
 public class BakeryService {
-    private static final String SEOUL_WORD = "서울";
+    private static final String SEOUL_WORD = "서울특별시";
     private static final String SEOUL_CITY_WORD = "서울특별시";
     private final BakeryRepository bakeryRepository;
     private final S3Service s3Service;
@@ -350,12 +350,12 @@ public class BakeryService {
                     .breadStyle(breadStyleResponseDto)
                     .build();
 
-            bakeries.add(bakery);
             bakery.addBakeryReview(userService.findById(3L), "통밀맛 존맛이에요 진짜루...", emojiService.findById(1L), filePaths, Arrays.asList("산딸기 케이크", "소보루빵"), fileHost, breadStyleResponseDto);
+            bakeries.add(bakery);
         }
 
         {
-            String city = "서울";
+            String city = "서울특별시";
             String content = "내가 진짜 수많은 빵을 먹어봤지만 태극당의 야채사라다는 진짜 최고였음... 이 야채사라다는" +
                     " 크기부터 완전 압도 ㅎㅎ 물론 가격대는 조금 있었지만 이 정도의 맛과 양이면 인정...그리고 " +
                     "일단 빵 자체가 너무 맛있음!!! 무엇보다 여긴 방문하면 어른들에게는 추억을~ " +
@@ -386,12 +386,12 @@ public class BakeryService {
                     .breadStyle(breadStyleResponseDto)
                     .build();
 
-            bakeries.add(bakery);
             bakery.addBakeryReview(userService.findById(2L), "버터케익 존맛이에요 진짜루...", emojiService.findById(1L), filePaths, Arrays.asList("태극당 모나카", "버터케익"), fileHost, breadStyleResponseDto);
+            bakeries.add(bakery);
         }
 
         {
-            String city = "서울";
+            String city = "서울특별시";
             String content = "말로만 듣던 서울3대빵집!!! 명성에 맞게 사람도 엄청 많고 넓고 빵종류도 어마어마했다!! " +
                     "다 너무 맛있어보여서 다 사고싶었지만ㅠㅠ 다른것도 다 맛있었지만 저 크고 하얀 크림치즈빵이 " +
                     "진짜 비주얼부터 맛까지 최고였다!! 빵피도 완전 쫀득쫀득하고 크림치즈도 가득 들어있다!!" +
@@ -422,14 +422,14 @@ public class BakeryService {
                     .breadStyle(breadStyleResponseDto)
                     .build();
 
-            bakeries.add(bakery);
             bakery.addBakeryReview(userService.findById(3L), "생크림빵 존맛이에요 진짜루...",
                     emojiService.findById(2L), filePaths,
                     Arrays.asList("생크림빵", "고소한 맛 사라다"), fileHost, breadStyleResponseDto);
+            bakeries.add(bakery);
         }
 
         {
-            String city = "서울";
+            String city = "서울특별시";
             String content = "통밀한빵 정말 맛있어요.";
             String description = "";
             String district = "마포구";
@@ -457,10 +457,10 @@ public class BakeryService {
                     .breadStyle(breadStyleResponseDto)
                     .build();
 
-            bakeries.add(bakery);
             bakery.addBakeryReview(userService.findById(3L), "슈크림 존맛이에요 진짜루...",
                     emojiService.findById(1L), filePaths, Arrays.asList("슈크림", "공주밤 파이"),
                     fileHost, breadStyleResponseDto);
+            bakeries.add(bakery);
         }
 
         bakeryRepository.saveAll(bakeries);

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/bakery/application/BakeryService.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/bakery/application/BakeryService.java
@@ -269,7 +269,7 @@ public class BakeryService {
 
         final String fileHost = "https://globaltwojob.com/";
         final List<String> filePaths = List.of("wp-content/uploads/2020/03/pixabay-252777_1920-1.jpg", "wp-content/uploads/2020/03/pixabay-252777_1920-1.jpg", "wp-content/uploads/2020/03/pixabay-252777_1920-1.jpg", "wp-content/uploads/2020/03/pixabay-252777_1920-1.jpg", "wp-content/uploads/2020/03/pixabay-252777_1920-1.jpg", "wp-content/uploads/2020/03/pixabay-252777_1920-1.jpg", "wp-content/uploads/2020/03/pixabay-252777_1920-1.jpg");
-        final UserResponseDto userResponseDto = userService.findById(3L);
+        final UserResponseDto userResponseDto = userService.findById(1L);
         final BakeryCategoryResponseDto bakeryCategoryResponseDto = bakeryCategoryService.findById(1L);
         final BakeryCategoryResponseDto bakeryCategoryResponseDto2 = bakeryCategoryService.findById(2L);
         final EmojiResponseDto emojiResponseDto = emojiService.findById(1L);
@@ -346,12 +346,121 @@ public class BakeryService {
                     .roadAddress(roadAddress)
                     .signatureMenus(signatureMenus)
                     .title(title)
-                    .user(userService.findById(1L))
+                    .user(userService.findById(2L))
                     .breadStyle(breadStyleResponseDto)
                     .build();
 
             bakeries.add(bakery);
             bakery.addBakeryReview(userService.findById(3L), "통밀맛 존맛이에요 진짜루...", emojiService.findById(1L), filePaths, Arrays.asList("산딸기 케이크", "소보루빵"), fileHost, breadStyleResponseDto);
+        }
+
+        {
+            String city = "서울";
+            String content = "내가 진짜 수많은 빵을 먹어봤지만 태극당의 야채사라다는 진짜 최고였음... 이 야채사라다는" +
+                    " 크기부터 완전 압도 ㅎㅎ 물론 가격대는 조금 있었지만 이 정도의 맛과 양이면 인정...그리고 " +
+                    "일단 빵 자체가 너무 맛있음!!! 무엇보다 여긴 방문하면 어른들에게는 추억을~ " +
+                    "아이들에게는 재미를 선사할 수 있음~^^";
+            String description = "";
+            String district = "중구";
+            double mapX = 37.559553;
+            double mapY = 127.005132;
+            String roadAddress = "서울 중구 동호로 24길 7";
+            List<String> signatureMenus = Arrays.asList("태극당 모나카", "버터케익");
+            String title = "태극당";
+
+            final Bakery bakery = Bakery.builder()
+                    .bakeryCategory(bakeryCategoryResponseDto2)
+                    .city(city)
+                    .content(content)
+                    .description(description)
+                    .district(district)
+                    .emoji(emojiResponseDto)
+                    .imgHost(fileHost)
+                    .imgUrls(filePaths)
+                    .mapX(mapX)
+                    .mapY(mapY)
+                    .roadAddress(roadAddress)
+                    .signatureMenus(signatureMenus)
+                    .title(title)
+                    .user(userService.findById(3L))
+                    .breadStyle(breadStyleResponseDto)
+                    .build();
+
+            bakeries.add(bakery);
+            bakery.addBakeryReview(userService.findById(2L), "버터케익 존맛이에요 진짜루...", emojiService.findById(1L), filePaths, Arrays.asList("태극당 모나카", "버터케익"), fileHost, breadStyleResponseDto);
+        }
+
+        {
+            String city = "서울";
+            String content = "말로만 듣던 서울3대빵집!!! 명성에 맞게 사람도 엄청 많고 넓고 빵종류도 어마어마했다!! " +
+                    "다 너무 맛있어보여서 다 사고싶었지만ㅠㅠ 다른것도 다 맛있었지만 저 크고 하얀 크림치즈빵이 " +
+                    "진짜 비주얼부터 맛까지 최고였다!! 빵피도 완전 쫀득쫀득하고 크림치즈도 가득 들어있다!!" +
+                    " 다음엔 케이크도 먹어보고싶다!!";
+            String description = "";
+            String district = "성북구";
+            double mapX = 37.554965;
+            double mapY = 126.855886;
+            String roadAddress = "서울 성북구 성북로 7";
+            List<String> signatureMenus = Arrays.asList("생크림빵", "고소한 맛 사라다");
+            String title = "나폴레옹과자점";
+
+            final Bakery bakery = Bakery.builder()
+                    .bakeryCategory(bakeryCategoryResponseDto2)
+                    .city(city)
+                    .content(content)
+                    .description(description)
+                    .district(district)
+                    .emoji(emojiResponseDto)
+                    .imgHost(fileHost)
+                    .imgUrls(filePaths)
+                    .mapX(mapX)
+                    .mapY(mapY)
+                    .roadAddress(roadAddress)
+                    .signatureMenus(signatureMenus)
+                    .title(title)
+                    .user(userService.findById(4L))
+                    .breadStyle(breadStyleResponseDto)
+                    .build();
+
+            bakeries.add(bakery);
+            bakery.addBakeryReview(userService.findById(3L), "생크림빵 존맛이에요 진짜루...",
+                    emojiService.findById(2L), filePaths,
+                    Arrays.asList("생크림빵", "고소한 맛 사라다"), fileHost, breadStyleResponseDto);
+        }
+
+        {
+            String city = "서울";
+            String content = "통밀한빵 정말 맛있어요.";
+            String description = "";
+            String district = "마포구";
+            double mapX = 37.554965;
+            double mapY = 126.855886;
+            String roadAddress = "서울 마포구 월드컵북로 86";
+            List<String> signatureMenus = Arrays.asList("슈크림", "공주밤 파이");
+            String title = "리치몬드 제과점";
+
+            final Bakery bakery = Bakery.builder()
+                    .bakeryCategory(bakeryCategoryResponseDto2)
+                    .city(city)
+                    .content(content)
+                    .description(description)
+                    .district(district)
+                    .emoji(emojiResponseDto)
+                    .imgHost(fileHost)
+                    .imgUrls(filePaths)
+                    .mapX(mapX)
+                    .mapY(mapY)
+                    .roadAddress(roadAddress)
+                    .signatureMenus(signatureMenus)
+                    .title(title)
+                    .user(userService.findById(5L))
+                    .breadStyle(breadStyleResponseDto)
+                    .build();
+
+            bakeries.add(bakery);
+            bakery.addBakeryReview(userService.findById(3L), "슈크림 존맛이에요 진짜루...",
+                    emojiService.findById(1L), filePaths, Arrays.asList("슈크림", "공주밤 파이"),
+                    fileHost, breadStyleResponseDto);
         }
 
         bakeryRepository.saveAll(bakeries);

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/bakery/application/BakeryService.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/bakery/application/BakeryService.java
@@ -44,7 +44,7 @@ import java.util.stream.Stream;
 @Service
 @RequiredArgsConstructor
 public class BakeryService {
-    private static final String SEOUL_WORD = "서울특별시";
+    private static final String SEOUL_WORD = "서울";
     private static final String SEOUL_CITY_WORD = "서울특별시";
     private final BakeryRepository bakeryRepository;
     private final S3Service s3Service;

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/bakery/application/dto/BakerySearchResponseDto.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/bakery/application/dto/BakerySearchResponseDto.java
@@ -22,7 +22,6 @@ public class BakerySearchResponseDto {
     @ApiModelProperty(value = "도로명 주소", example = "서울 강서구 화곡로64길 70")
     private final String roadAddress;
 
-
     @ApiModelProperty(value = "X좌표", example = "1.41211704222904E7")
     private final Double mapX;
     @ApiModelProperty(value = "Y좌표", example = "4516889.7719205")
@@ -34,6 +33,9 @@ public class BakerySearchResponseDto {
     private final String profileImgUrl;
     @ApiModelProperty(value = "빵집 카드 빵 스타일 이름", example = "\"크림\"")
     private final String breadStyleName;
+
+    @ApiModelProperty(value = "빵집 카드 빵 스타일 색상", example = "\"#EEEEEE\"")
+    private final String breadStyleColor;
     @ApiModelProperty(value = "빵집 카드 닉네임", example = "테스트유저2")
     private final String nickName;
 
@@ -59,6 +61,7 @@ public class BakerySearchResponseDto {
         this.userId = userResponseDto.getId();
         this.profileImgUrl = userResponseDto.getProfileImgUrl();
         this.breadStyleName = userResponseDto.getBreadStyleName();
+        this.breadStyleColor = userResponseDto.getBreadStyleColor();
         this.nickName = userResponseDto.getNickName();
         this.categoryTitle = bakeryCategoryResponseDto.getTitle();
         this.makerImgUrl = bakeryCategoryResponseDto.getMakerImgUrl();

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/application/BreadStyleService.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/application/BreadStyleService.java
@@ -33,7 +33,8 @@ public class BreadStyleService {
 
     @Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
     public BreadStyleResponseDto findById(Long breadStyleId) {
-        final BreadStyle breadStyle = breadStyleRepository.findById(breadStyleId).orElseThrow(() -> new BreadStyleNotFoundException("id", Long.toString(breadStyleId)));
+        final BreadStyle breadStyle = breadStyleRepository.findById(breadStyleId)
+                .orElseThrow(() -> new BreadStyleNotFoundException("id", Long.toString(breadStyleId)));
         return new BreadStyleResponseDto(breadStyle);
     }
 }

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/application/BreadStyleService.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/application/BreadStyleService.java
@@ -24,6 +24,7 @@ public class BreadStyleService {
         breadStyleRepository.saveAll(new InitBreadStyleData().get());
     }
 
+    @Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
     public List<BreadStyleResponseDto> findAll() {
         return breadStyleRepository.findAllOrderByIdDesc().stream()
                 .map(BreadStyleResponseDto::new)

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/application/BreadStyleService.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/application/BreadStyleService.java
@@ -7,6 +7,7 @@ import com.bside.breadgood.ddd.breadstyles.infra.InitBreadStyleData;
 import com.bside.breadgood.ddd.breadstyles.ui.dto.BreadStyleResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -29,6 +30,7 @@ public class BreadStyleService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
     public BreadStyleResponseDto findById(Long breadStyleId) {
         final BreadStyle breadStyle = breadStyleRepository.findById(breadStyleId).orElseThrow(() -> new BreadStyleNotFoundException("id", Long.toString(breadStyleId)));
         return new BreadStyleResponseDto(breadStyle);

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/domain/BreadStyle.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/domain/BreadStyle.java
@@ -2,38 +2,44 @@ package com.bside.breadgood.ddd.breadstyles.domain;
 
 
 import com.bside.breadgood.common.domain.BaseEntity;
+import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-//@EqualsAndHashCode(of = "id", callSuper = false)
 public class BreadStyle extends BaseEntity {
 
     @Id
     @Column(name = "bread_style_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-    //  이름
+
+    // 이름
     private String name;
     // 설명글
     private String content;
-    // 설명 이미지
+    // 최애빵 스타일 설명 이미지
     private String imgUrl;
-
-    @Column(nullable = true)
+    // 최애빵 스타일 프로필 이미지
     private String profileImgUrl;
+    // 최애빵 색상
+    private String color;
 
     @Builder
-    public BreadStyle(String name, String content, String imgUrl, String profileImgUrl) {
+    public BreadStyle(String name, String content, String imgUrl, String profileImgUrl, String color) {
         this.name = name;
         this.content = content;
         this.imgUrl = imgUrl;
         this.profileImgUrl = profileImgUrl;
+        this.color = color;
     }
 }

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/domain/BreadStyle.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/domain/BreadStyle.java
@@ -2,20 +2,28 @@ package com.bside.breadgood.ddd.breadstyles.domain;
 
 
 import com.bside.breadgood.common.domain.BaseEntity;
+import com.bside.breadgood.common.exception.EmptyException;
+import com.bside.breadgood.common.vo.ImageUrl;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
+import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"name"}, name = "unique_bread_style_name")})
 public class BreadStyle extends BaseEntity {
 
     @Id
@@ -24,22 +32,58 @@ public class BreadStyle extends BaseEntity {
     private long id;
 
     // 이름
+    @Column(nullable = false)
     private String name;
     // 설명글
+    @Column(nullable = false)
     private String content;
     // 최애빵 스타일 설명 이미지
-    private String imgUrl;
+    @Embedded
+    @AttributeOverride(name = "imgUrl", column = @Column(name = "contentImgUrl", nullable = false))
+    private ImageUrl contentImgUrl;
+    @Embedded
+    @AttributeOverride(name = "imgUrl", column = @Column(name = "profileImgUrl", nullable = false))
     // 최애빵 스타일 프로필 이미지
-    private String profileImgUrl;
+    private ImageUrl profileImgUrl;
     // 최애빵 색상
+    @Column(nullable = false, length = 50)
     private String color;
 
     @Builder
-    public BreadStyle(String name, String content, String imgUrl, String profileImgUrl, String color) {
+    public BreadStyle(String name, String content, String contentImgUrl, String profileImgUrl, String color) {
+
+        if (!StringUtils.hasText(name)) {
+            throw new EmptyException("최애빵 스타일 이름이 없습니다.");
+        }
+
+        if (!StringUtils.hasText(content)) {
+            throw new EmptyException("최애빵 스타일 설명이 없습니다.");
+        }
+
+        if (!StringUtils.hasText(contentImgUrl)) {
+            throw new EmptyException("최애빵 스타일 설명 이미지가 없습니다.");
+        }
+
+        if (!StringUtils.hasText(profileImgUrl)) {
+            throw new EmptyException("최애빵 스타일 프로필 이미지가 없습니다.");
+        }
+
+        if (!StringUtils.hasText(color)) {
+            throw new EmptyException("최애빵 스타일 색상이 없습니다.");
+        }
+
         this.name = name;
         this.content = content;
-        this.imgUrl = imgUrl;
-        this.profileImgUrl = profileImgUrl;
+        this.contentImgUrl = ImageUrl.from(contentImgUrl);
+        this.profileImgUrl = ImageUrl.from(profileImgUrl);
         this.color = color;
+    }
+
+    public String getContentImgUrl() {
+        return contentImgUrl.getImgUrl();
+    }
+
+    public String getProfileImgUrl() {
+        return profileImgUrl.getImgUrl();
     }
 }

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/infra/InitBreadStyleData.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/infra/InitBreadStyleData.java
@@ -26,7 +26,6 @@ public class InitBreadStyleData {
                         "짭짤한 맛의 조리빵", "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_salty_.png",
                 "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_salty.png",
                 "#FFBC4A");
-
         add("담백", "식빵, 바게트, 치아바타, \n" +
                         "크루아상, 베이글 등\n" +
                         "자극적이지 않은 담백한 빵", "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_plain_.png",

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/infra/InitBreadStyleData.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/infra/InitBreadStyleData.java
@@ -15,22 +15,22 @@ public class InitBreadStyleData {
                         "맘모스빵 케이크 등 \n" +
                         "크림이 가득 든 빵", "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_cream_.png",
                 "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_cream.png",
-                "#FFB39A");
+                "#fd9573");
         add("달콤", "단팥빵, 연유브레드,\n" +
                         "시나몬롤 등 \n" +
                         "크림이 없는 달콤한 빵", "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_sweet_.png",
                 "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_sweet.png",
-                "#D48F62");
+                "#7d9573");
         add("짭짤", "피자빵, 고로케,양파빵, \n" +
                         "마늘바게트 등 \n" +
                         "짭짤한 맛의 조리빵", "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_salty_.png",
                 "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_salty.png",
-                "#FFBC4A");
+                "#f3b54c");
         add("담백", "식빵, 바게트, 치아바타, \n" +
                         "크루아상, 베이글 등\n" +
                         "자극적이지 않은 담백한 빵", "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_plain_.png",
                 "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_plain.png",
-                "#8FBCFF");
+                "#70a9ff");
 
 
     }

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/infra/InitBreadStyleData.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/infra/InitBreadStyleData.java
@@ -20,7 +20,7 @@ public class InitBreadStyleData {
                         "시나몬롤 등 \n" +
                         "크림이 없는 달콤한 빵", "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_sweet_.png",
                 "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_sweet.png",
-                "#7d9573");
+                "#c59577");
         add("짭짤", "피자빵, 고로케,양파빵, \n" +
                         "마늘바게트 등 \n" +
                         "짭짤한 맛의 조리빵", "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_salty_.png",

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/infra/InitBreadStyleData.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/infra/InitBreadStyleData.java
@@ -14,20 +14,24 @@ public class InitBreadStyleData {
         add("크림", "생크림빵, 슈크림빵, \n" +
                         "맘모스빵 케이크 등 \n" +
                         "크림이 가득 든 빵", "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_cream_.png",
-                "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_cream.png");
+                "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_cream.png",
+                "#FFB39A");
         add("달콤", "단팥빵, 연유브레드,\n" +
                         "시나몬롤 등 \n" +
                         "크림이 없는 달콤한 빵", "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_sweet_.png",
-                "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_sweet.png");
+                "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_sweet.png",
+                "#D48F62");
         add("짭짤", "피자빵, 고로케,양파빵, \n" +
                         "마늘바게트 등 \n" +
                         "짭짤한 맛의 조리빵", "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_salty_.png",
-                "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_salty.png");
+                "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_salty.png",
+                "#FFBC4A");
 
         add("담백", "식빵, 바게트, 치아바타, \n" +
                         "크루아상, 베이글 등\n" +
                         "자극적이지 않은 담백한 빵", "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_plain_.png",
-                "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_plain.png");
+                "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_plain.png",
+                "#8FBCFF");
 
 
     }
@@ -36,7 +40,7 @@ public class InitBreadStyleData {
         return data;
     }
 
-    private void add(String name, String content, String imgUrl, String porfileImgUrl) {
-        data.add(new BreadStyle(name, content, imgUrl, porfileImgUrl));
+    private void add(String name, String content, String imgUrl, String porfileImgUrl, String color) {
+        data.add(new BreadStyle(name, content, imgUrl, porfileImgUrl, color));
     }
 }

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/ui/BreadStyleControllerAdvice.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/ui/BreadStyleControllerAdvice.java
@@ -21,7 +21,7 @@ public class BreadStyleControllerAdvice extends ExceptionAdvice {
     }
 
     @ExceptionHandler(BreadStyleNotFoundException.class)
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     protected ExceptionResponse breadStyleNotFoundException(BreadStyleNotFoundException ex, WebRequest request) {
         String messagePath = super.getMessagePathByMyMethodName();
         return super.getExceptionResponse(request, messagePath, ex.getArgs());

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/ui/dto/BreadStyleResponseDto.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/ui/dto/BreadStyleResponseDto.java
@@ -21,7 +21,7 @@ public class BreadStyleResponseDto {
         this.id = entity.getId();
         this.name = entity.getName();
         this.content = entity.getContent();
-        this.imgUrl = entity.getImgUrl();
+        this.imgUrl = entity.getContentImgUrl();
         this.profileImgUrl = entity.getProfileImgUrl();
         this.color = entity.getColor();
     }

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/ui/dto/BreadStyleResponseDto.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/ui/dto/BreadStyleResponseDto.java
@@ -3,6 +3,8 @@ package com.bside.breadgood.ddd.breadstyles.ui.dto;
 import com.bside.breadgood.ddd.breadstyles.domain.BreadStyle;
 import lombok.Getter;
 
+import java.util.Objects;
+
 @Getter
 public class BreadStyleResponseDto {
     private final Long id;
@@ -24,5 +26,32 @@ public class BreadStyleResponseDto {
         this.imgUrl = entity.getContentImgUrl();
         this.profileImgUrl = entity.getProfileImgUrl();
         this.color = entity.getColor();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        BreadStyleResponseDto that = (BreadStyleResponseDto) o;
+
+        if (!Objects.equals(id, that.id)) return false;
+        if (!Objects.equals(name, that.name)) return false;
+        if (!Objects.equals(content, that.content)) return false;
+        if (!Objects.equals(imgUrl, that.imgUrl)) return false;
+        if (!Objects.equals(profileImgUrl, that.profileImgUrl))
+            return false;
+        return Objects.equals(color, that.color);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        result = 31 * result + (content != null ? content.hashCode() : 0);
+        result = 31 * result + (imgUrl != null ? imgUrl.hashCode() : 0);
+        result = 31 * result + (profileImgUrl != null ? profileImgUrl.hashCode() : 0);
+        result = 31 * result + (color != null ? color.hashCode() : 0);
+        return result;
     }
 }

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/ui/dto/BreadStyleResponseDto.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/breadstyles/ui/dto/BreadStyleResponseDto.java
@@ -12,8 +12,10 @@ public class BreadStyleResponseDto {
     private final String content;
     // 설명 이미지
     private final String imgUrl;
-
+    // 프로필 이미지
     private final String profileImgUrl;
+    // 최애빵 색상
+    private String color;
 
     public BreadStyleResponseDto(BreadStyle entity) {
         this.id = entity.getId();
@@ -21,5 +23,6 @@ public class BreadStyleResponseDto {
         this.content = entity.getContent();
         this.imgUrl = entity.getImgUrl();
         this.profileImgUrl = entity.getProfileImgUrl();
+        this.color = entity.getColor();
     }
 }

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/application/UserInfoResponseDto.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/application/UserInfoResponseDto.java
@@ -11,7 +11,7 @@ public class UserInfoResponseDto {
             .breadStyleName(null)
             .userId(0L)
             .nickName("빵긋")
-            .breadStyleColor("#B0B0B0")
+            .breadStyleColor("#696972")
             .profileImgUrl("https://d74hbwjus7qtu.cloudfront.net/admin/case_2_off.png")
             .isWithdrawal(false)
             .build();

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/application/UserInfoResponseDto.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/application/UserInfoResponseDto.java
@@ -11,16 +11,18 @@ public class UserInfoResponseDto {
     private final String profileImgUrl;
     private final Long breadStyleId;
     private final String breadStyleName;
+    private final String breadStyleColor;
     private final boolean isWithdrawal;
 
 
     @Builder
-    public UserInfoResponseDto(Long userId, String nickName, String profileImgUrl, Long breadStyleId, String breadStyleName, boolean isWithdrawal) {
+    public UserInfoResponseDto(Long userId, String nickName, String profileImgUrl, Long breadStyleId, String breadStyleName, String breadStyleColor, boolean isWithdrawal) {
         this.id = userId;
         this.nickName = nickName;
         this.profileImgUrl = profileImgUrl;
         this.breadStyleId = breadStyleId;
         this.breadStyleName = breadStyleName;
+        this.breadStyleColor = breadStyleColor;
         this.isWithdrawal = isWithdrawal;
     }
 }

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/application/UserInfoResponseDto.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/application/UserInfoResponseDto.java
@@ -6,6 +6,16 @@ import lombok.Getter;
 @Getter
 public class UserInfoResponseDto {
 
+    public static final UserInfoResponseDto DEFAULT_USER_INFO_RESPONSE_DTO = UserInfoResponseDto.builder()
+            .breadStyleId(null)
+            .breadStyleName(null)
+            .userId(0L)
+            .nickName("빵긋")
+            .breadStyleColor("#B0B0B0")
+            .profileImgUrl("https://d74hbwjus7qtu.cloudfront.net/admin/case_2_off.png")
+            .isWithdrawal(false)
+            .build();
+
     private final Long id;
     private final String nickName;
     private final String profileImgUrl;
@@ -13,7 +23,6 @@ public class UserInfoResponseDto {
     private final String breadStyleName;
     private final String breadStyleColor;
     private final boolean isWithdrawal;
-
 
     @Builder
     public UserInfoResponseDto(Long userId, String nickName, String profileImgUrl, Long breadStyleId, String breadStyleName, String breadStyleColor, boolean isWithdrawal) {
@@ -24,5 +33,9 @@ public class UserInfoResponseDto {
         this.breadStyleName = breadStyleName;
         this.breadStyleColor = breadStyleColor;
         this.isWithdrawal = isWithdrawal;
+    }
+
+    public static UserInfoResponseDto getDefault() {
+        return DEFAULT_USER_INFO_RESPONSE_DTO;
     }
 }

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/application/UserService.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/application/UserService.java
@@ -17,6 +17,7 @@ import com.bside.breadgood.ddd.users.infra.WithdrawalUserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
@@ -37,9 +38,11 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserResponseDto findById(Long userId) {
         final User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException("id", Long.toString(userId)));
+        if (user.isGuest()) {
+            return new UserResponseDto(user);
+        }
         final BreadStyleResponseDto breadStyleResponseDto = breadStyleService.findById(user.getBreadStyle());
         return new UserResponseDto(user, breadStyleResponseDto);
-
     }
 
     /**
@@ -172,6 +175,7 @@ public class UserService {
 
     }
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void initData() {
         userRepository.saveAll(new InitUserData().get());
     }

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/application/UserService.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/application/UserService.java
@@ -57,6 +57,7 @@ public class UserService {
             return UserInfoResponseDto.builder()
                     .breadStyleId(breadStyleResponseDto.getId())
                     .breadStyleName(breadStyleResponseDto.getName())
+                    .breadStyleColor(breadStyleResponseDto.getColor())
                     .userId(user.getId())
                     .nickName(user.getNickName())
                     .profileImgUrl(user.getProfileImg())
@@ -72,6 +73,7 @@ public class UserService {
                     .breadStyleName(null)
                     .userId(0L)
                     .nickName("빵긋")
+                    .breadStyleColor("#D8D8D8")
                     .profileImgUrl("https://d74hbwjus7qtu.cloudfront.net/admin/case_2_off.png")
                     .isWithdrawal(false)
                     .build();

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/application/dto/UserResponseDto.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/application/dto/UserResponseDto.java
@@ -12,9 +12,9 @@ public class UserResponseDto {
     private final String nickName;
     private final Long breadStyleId;
 
-    public UserResponseDto(User user) {
+    public UserResponseDto(User user, BreadStyleResponseDto breadStyleResponseDto) {
         this.id = user.getId();
-        this.profileImgUrl = user.getProfileImg();
+        this.profileImgUrl = breadStyleResponseDto.getProfileImgUrl();
         this.nickName = user.getNickName();
         this.breadStyleId = user.getBreadStyle();
     }

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/application/dto/UserResponseDto.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/application/dto/UserResponseDto.java
@@ -18,4 +18,11 @@ public class UserResponseDto {
         this.nickName = user.getNickName();
         this.breadStyleId = user.getBreadStyle();
     }
+
+    public UserResponseDto(User user) {
+        this.id = user.getId();
+        this.profileImgUrl = null;
+        this.nickName = user.getNickName();
+        this.breadStyleId = user.getBreadStyle();
+    }
 }

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/domain/User.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/domain/User.java
@@ -1,22 +1,26 @@
 package com.bside.breadgood.ddd.users.domain;
 
 import com.bside.breadgood.common.domain.BaseEntity;
-import com.bside.breadgood.ddd.breadstyles.domain.BreadStyle;
 import com.bside.breadgood.ddd.breadstyles.ui.dto.BreadStyleResponseDto;
-import com.bside.breadgood.ddd.termstype.domain.TermsType;
 import com.bside.breadgood.ddd.termstype.ui.dto.TermsTypeResponseDto;
 import com.sun.istack.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.thymeleaf.util.StringUtils;
 
-import javax.persistence.*;
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Getter
@@ -40,19 +44,16 @@ public class User extends BaseEntity {
     @AttributeOverrides({
             @AttributeOverride(name = "email", column = @Column(name = "email"))
     })
-
     private Email email;
 
     private String password;
 
     private Long breadStyle;
 
-    private String profileImg;
-
     @ElementCollection
     private List<UserTerms> userTerms;
 
-    @Enumerated
+    @Embedded
     private SocialLink socialLink;
 
     @NotNull
@@ -68,12 +69,11 @@ public class User extends BaseEntity {
         this.role = role;
     }
 
-    public User(String nickName, String email, String password, Long breadStyle, String profileImg, List<UserTerms> userTerms, Role role) {
+    public User(String nickName, String email, String password, Long breadStyle, List<UserTerms> userTerms, Role role) {
         this.nickName = NickName.valueOf(nickName);
         this.email = Email.valueOf(email);
         this.password = password;
         this.breadStyle = breadStyle;
-        this.profileImg = profileImg;
         this.userTerms = userTerms;
         this.role = role;
     }
@@ -82,7 +82,6 @@ public class User extends BaseEntity {
     public void socialGuestSignUp(String nickName, BreadStyleResponseDto breadStyle, List<TermsTypeResponseDto> termsTypes) {
         this.nickName = NickName.valueOf(nickName);
         this.breadStyle = breadStyle.getId();
-        this.profileImg = breadStyle.getProfileImgUrl();
         setUserTerms(termsTypes);
         this.role = Role.USER;
     }
@@ -107,7 +106,6 @@ public class User extends BaseEntity {
 
     public void updateBreadStyle(BreadStyleResponseDto breadStyleResponseDto) {
         this.breadStyle = breadStyleResponseDto.getId();
-        this.profileImg = breadStyleResponseDto.getProfileImgUrl();
     }
 
     public String getNickName() {

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/domain/User.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/domain/User.java
@@ -121,4 +121,8 @@ public class User extends BaseEntity {
         }
         return email.getEmail();
     }
+
+    public boolean isGuest() {
+        return this.role == Role.GUEST;
+    }
 }

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/infra/InitUserData.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/infra/InitUserData.java
@@ -1,6 +1,5 @@
 package com.bside.breadgood.ddd.users.infra;
 
-import com.bside.breadgood.ddd.bakerycategory.domain.BakeryCategory;
 import com.bside.breadgood.ddd.users.domain.Role;
 import com.bside.breadgood.ddd.users.domain.User;
 import com.bside.breadgood.ddd.users.domain.UserTerms;
@@ -42,12 +41,12 @@ public class InitUserData {
         final BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
         final String password = bCryptPasswordEncoder.encode("1234");
 
-        add("테스트유저", "test@breadgood.com", password, 1L, "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_cream.png", userTermsList, role);
-        add("테스트유저2", "test2@breadgood.com", password, 2L, "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_sweet.png", userTermsList, role);
-        add("테스트유저3", "test3@breadgood.com", password, 2L, "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_sweet.png", userTermsList, role);
-        add("테스트유저4", "test4@breadgood.com", password, 3L, "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_salty.png", userTermsList, role);
-        add("테스트유저5", "test5@breadgood.com", password, 3L, "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_salty.png", userTermsList, role);
-        add("테스트유저6", "test6@breadgood.com", password, 3L, "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_salty.png", userTermsList, role);
+        add("테스트유저", "test@breadgood.com", password, 1L, userTermsList, role);
+        add("테스트유저2", "test2@breadgood.com", password, 2L, userTermsList, role);
+        add("테스트유저3", "test3@breadgood.com", password, 2L, userTermsList, role);
+        add("테스트유저4", "test4@breadgood.com", password, 3L, userTermsList, role);
+        add("테스트유저5", "test5@breadgood.com", password, 3L, userTermsList, role);
+        add("테스트유저6", "test6@breadgood.com", password, 3L, userTermsList, role);
 
     }
 
@@ -55,8 +54,8 @@ public class InitUserData {
         return data;
     }
 
-    private void add(String nickName, String email, String password, Long breadStyle, String profileImg, List<UserTerms> userTerms, Role role) {
-        data.add(new User(nickName, email, password, breadStyle, profileImg, userTerms, role));
+    private void add(String nickName, String email, String password, Long breadStyle, List<UserTerms> userTerms, Role role) {
+        data.add(new User(nickName, email, password, breadStyle, userTerms, role));
     }
 
 }

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/infra/InitUserData.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/infra/InitUserData.java
@@ -13,7 +13,7 @@ import java.util.Set;
 
 public class InitUserData {
 
-    Set<User> data = new HashSet<>();
+    List<User> data = new ArrayList<>();
 
     {
 
@@ -50,7 +50,7 @@ public class InitUserData {
 
     }
 
-    public Set<User> get() {
+    public List<User> get() {
         return data;
     }
 

--- a/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/infra/InitUserData.java
+++ b/breadgood-server/src/main/java/com/bside/breadgood/ddd/users/infra/InitUserData.java
@@ -43,10 +43,10 @@ public class InitUserData {
 
         add("테스트유저", "test@breadgood.com", password, 1L, userTermsList, role);
         add("테스트유저2", "test2@breadgood.com", password, 2L, userTermsList, role);
-        add("테스트유저3", "test3@breadgood.com", password, 2L, userTermsList, role);
+        add("테스트유저3", "test3@breadgood.com", password, 3L, userTermsList, role);
         add("테스트유저4", "test4@breadgood.com", password, 3L, userTermsList, role);
-        add("테스트유저5", "test5@breadgood.com", password, 3L, userTermsList, role);
-        add("테스트유저6", "test6@breadgood.com", password, 3L, userTermsList, role);
+        add("테스트유저5", "test5@breadgood.com", password, 4L, userTermsList, role);
+        add("테스트유저6", "test6@breadgood.com", password, 1L, userTermsList, role);
 
     }
 

--- a/breadgood-server/src/main/resources/templates/pages/bakeryDetail.html
+++ b/breadgood-server/src/main/resources/templates/pages/bakeryDetail.html
@@ -20,7 +20,12 @@
                 <div class="bc-h-profile-img">
                     <img style="width: 22px;height: 22px;" :src="writerProfileImgUrl" alt="프로필 이미지">
                 </div>
-                <div class="bc-h-profile-txt"><span><span v-text="writerNickName">빵쳐돌이</span>님 최애빵집</span></div>
+                <div class="bc-h-profile-txt">
+                    <span>
+                        <span v-text="writerNickName">빵쳐돌이</span>
+                        <span :style="{color: breadStyleColor}">Pick</span>
+                    </span>
+                </div>
             </div>
             <div class="bc-h-title">
                 <div class="bakery-title">
@@ -156,6 +161,7 @@
             data: {
                 bakeryReviews: [],
                 categoryTitle: '',
+                breadStyleColor: '',
                 roadAddress: '',
                 title: '',
                 writerNickName: '',
@@ -184,6 +190,7 @@
 
                     this.writerProfileImgUrl = data.userInfoResponseDto.profileImgUrl;
                     this.writerNickName = data.userInfoResponseDto.nickName;
+                    this.breadStyleColor = data.userInfoResponseDto.breadStyleColor;
                     this.title = data.title;
                     this.roadAddress = data.roadAddress;
                     this.categoryTitle = data.categoryTitle;

--- a/breadgood-server/src/test/java/com/bside/breadgood/common/vo/ImageUrlTest.java
+++ b/breadgood-server/src/test/java/com/bside/breadgood/common/vo/ImageUrlTest.java
@@ -1,0 +1,40 @@
+package com.bside.breadgood.common.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("ImageUrl ValueObject 생성 테스트")
+class ImageUrlTest {
+
+    @ParameterizedTest(name = " \"{0}\" 빈값일 경우 오류가 발생한다.")
+    @NullAndEmptySource
+    void fromWithEmpty(String name) {
+        assertThrows(RuntimeException.class, () -> ImageUrl.from(name));
+    }
+
+    @ParameterizedTest(name = " \"{0}\" URL 형식이 아닐 경우 오류가 발생한다.")
+    @ValueSource(strings = {"asd", "htt.resouser.com", "aaaskjkdfasdfadf.png"})
+    void fromNotURL(String name) {
+        assertThrows(RuntimeException.class, () -> ImageUrl.from(name));
+    }
+
+    @ParameterizedTest(name = " \"{0}\" 지원하지 않는 확장자 일 경우 오류가 발생한다.")
+    @ValueSource(strings = {
+            "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_off.pn",
+            "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_off.afg"
+    })
+    void fromNotSupportExtension(String name) {
+        assertThrows(RuntimeException.class, () -> ImageUrl.from(name));
+    }
+
+    @Test
+    void from() {
+        assertDoesNotThrow(() -> ImageUrl.from("https://d74hbwjus7qtu.cloudfront.net/admin/case_2_off.png"));
+    }
+}

--- a/breadgood-server/src/test/java/com/bside/breadgood/ddd/breadstyles/application/BreadStyleFixture.java
+++ b/breadgood-server/src/test/java/com/bside/breadgood/ddd/breadstyles/application/BreadStyleFixture.java
@@ -1,0 +1,26 @@
+package com.bside.breadgood.ddd.breadstyles.application;
+
+import com.bside.breadgood.ddd.breadstyles.domain.BreadStyle;
+
+public class BreadStyleFixture {
+    public static final BreadStyle 담백 = BreadStyle.builder()
+            .content("식빵, 바게트, 치아바타, \n" +
+                    "크루아상, 베이글 등\n" +
+                    "자극적이지 않은 담백한 빵")
+            .name("담백")
+            .color("#8FBCFF")
+            .contentImgUrl("https://d74hbwjus7qtu.cloudfront.net/admin/case_1_plain.png")
+            .profileImgUrl("https://d74hbwjus7qtu.cloudfront.net/admin/case_2_plain_.png")
+            .build();
+
+
+    public static final BreadStyle 짭짤 = BreadStyle.builder()
+            .content("피자빵, 고로케,양파빵, \n" +
+                    "마늘바게트 등 \n" +
+                    "짭짤한 맛의 조리빵")
+            .name("짭짤")
+            .color("#FFBC4A")
+            .contentImgUrl("https://d74hbwjus7qtu.cloudfront.net/admin/case_2_salty_.png")
+            .profileImgUrl("https://d74hbwjus7qtu.cloudfront.net/admin/case_1_salty.png")
+            .build();
+}

--- a/breadgood-server/src/test/java/com/bside/breadgood/ddd/breadstyles/application/BreadStyleServiceTest.java
+++ b/breadgood-server/src/test/java/com/bside/breadgood/ddd/breadstyles/application/BreadStyleServiceTest.java
@@ -1,0 +1,73 @@
+package com.bside.breadgood.ddd.breadstyles.application;
+
+import com.bside.breadgood.ddd.breadstyles.application.exception.BreadStyleNotFoundException;
+import com.bside.breadgood.ddd.breadstyles.domain.BreadStyle;
+import com.bside.breadgood.ddd.breadstyles.infra.BreadStyleRepository;
+import com.bside.breadgood.ddd.breadstyles.ui.dto.BreadStyleResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static com.bside.breadgood.ddd.breadstyles.application.BreadStyleFixture.담백;
+import static com.bside.breadgood.ddd.breadstyles.application.BreadStyleFixture.짭짤;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+@DisplayName("최애빵 스타일 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class BreadStyleServiceTest {
+
+    @Mock
+    private BreadStyleRepository breadStyleRepository;
+
+    @InjectMocks
+    private BreadStyleService breadStyleService;
+
+    @Test
+    @DisplayName("최애빵 스타일 리스트 조회")
+    void findAll() {
+        // given
+        final List<BreadStyle> expected = Arrays.asList(담백, 짭짤);
+        given(breadStyleRepository.findAllOrderByIdDesc()).willReturn(expected);
+        // when
+        List<BreadStyleResponseDto> actual = breadStyleService.findAll();
+        // then
+        assertThat(actual).containsExactlyElementsOf(
+                Arrays.asList(new BreadStyleResponseDto(담백),
+                        new BreadStyleResponseDto(짭짤)
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("최애빵 스타일 조회")
+    void findById() {
+        // given
+        BreadStyle expected = 담백;
+        given(breadStyleRepository.findById(anyLong())).willReturn(Optional.of(expected));
+        // when
+        final BreadStyleResponseDto actual = breadStyleService.findById(anyLong());
+        // then
+        assertThat(actual).isEqualTo(new BreadStyleResponseDto(담백));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 최애빵 스타일 조회시 오류가 발생한다.")
+    void findByIdWithNotFound() {
+        // given
+        given(breadStyleRepository.findById(anyLong())).willReturn(Optional.empty());
+        // when
+        assertThrows(BreadStyleNotFoundException.class, () -> {
+            breadStyleService.findById(anyLong());
+        });
+    }
+}

--- a/breadgood-server/src/test/java/com/bside/breadgood/ddd/breadstyles/domain/BreadStyleTest.java
+++ b/breadgood-server/src/test/java/com/bside/breadgood/ddd/breadstyles/domain/BreadStyleTest.java
@@ -1,0 +1,137 @@
+package com.bside.breadgood.ddd.breadstyles.domain;
+
+import com.bside.breadgood.ddd.breadstyles.infra.BreadStyleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class BreadStyleTest {
+
+    @Autowired
+    BreadStyleRepository repository;
+
+    @Test
+    @DisplayName("최애빵 스타일 등록")
+    void save() {
+
+        final String content = "식빵, 바게트, 치아바타, \n" +
+                "크루아상, 베이글 등\n" +
+                "자극적이지 않은 담백한 빵";
+        final String name = "담백";
+        final String color = "#8FBCFF";
+        final String url = "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_plain.png";
+        final String profileImgUrl = "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_plain_.png";
+        final BreadStyle breadStyle = BreadStyle.builder()
+                .content(content)
+                .name(name)
+                .color(color)
+                .contentImgUrl(url)
+                .profileImgUrl(profileImgUrl)
+                .build();
+
+        final BreadStyle savedBreadStyle = repository.save(breadStyle);
+
+        assertAll(
+                () -> assertThat(savedBreadStyle.getId()).isNotNull(),
+                () -> assertThat(savedBreadStyle.getName()).isEqualTo(name),
+                () -> assertThat(savedBreadStyle.getContent()).isEqualTo(content),
+                () -> assertThat(savedBreadStyle.getContentImgUrl()).isEqualTo(url),
+                () -> assertThat(savedBreadStyle.getProfileImgUrl()).isEqualTo(profileImgUrl)
+        );
+
+    }
+
+    @ParameterizedTest(name = " \"{0}\" 이름이 빈값일 경우 오류가 발생한다.")
+    @NullAndEmptySource
+    void saveWithEmptyName(String name) {
+
+        final String content = "식빵, 바게트, 치아바타, \n" +
+                "크루아상, 베이글 등\n" +
+                "자극적이지 않은 담백한 빵";
+        final String color = "#8FBCFF";
+        final String url = "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_plain.png";
+        final String profileImgUrl = "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_plain_.png";
+
+
+        assertThrowsBuildBreadStyle(content, name, color, url, profileImgUrl);
+    }
+
+    @ParameterizedTest(name = " \"{0}\" 설명이 빈값일 경우 오류가 발생한다.")
+    @NullAndEmptySource
+    void saveWithEmptyContent(String content) {
+        final String name = "담백";
+        final String color = "#8FBCFF";
+        final String url = "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_plain.png";
+        final String profileImgUrl = "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_plain_.png";
+
+        assertThrowsBuildBreadStyle(content, name, color, url, profileImgUrl);
+    }
+
+    @ParameterizedTest(name = " \"{0}\" 색상값이 빈 경우 오류가 발생한다.")
+    @NullAndEmptySource
+    void saveWithEmptyColor(String color) {
+
+        final String content = "식빵, 바게트, 치아바타, \n" +
+                "크루아상, 베이글 등\n" +
+                "자극적이지 않은 담백한 빵";
+        final String name = "담백";
+        final String url = "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_plain.png";
+        final String profileImgUrl = "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_plain_.png";
+
+
+        assertThrowsBuildBreadStyle(content, name, color, url, profileImgUrl);
+    }
+
+    @ParameterizedTest(name = " \"{0}\" 설명 이미지가 빈값일 경우 오류가 발생한다.")
+    @NullAndEmptySource
+    void saveWithEmptyContentUrl(String url) {
+
+        final String content = "식빵, 바게트, 치아바타, \n" +
+                "크루아상, 베이글 등\n" +
+                "자극적이지 않은 담백한 빵";
+        final String name = "담백";
+        final String color = "#8FBCFF";
+        final String profileImgUrl = "https://d74hbwjus7qtu.cloudfront.net/admin/case_2_plain_.png";
+
+        assertThrowsBuildBreadStyle(content, name, color, url, profileImgUrl);
+    }
+
+
+    @ParameterizedTest(name = " \"{0}\" 최애빵 프로필 사진이 빈 경우 오류가 발생한다.")
+    @NullAndEmptySource
+    void saveWithEmptyProfileImgUrl(String profileImgUrl) {
+
+        final String content = "식빵, 바게트, 치아바타, \n" +
+                "크루아상, 베이글 등\n" +
+                "자극적이지 않은 담백한 빵";
+        final String name = "담백";
+        final String color = "#8FBCFF";
+        final String url = "https://d74hbwjus7qtu.cloudfront.net/admin/case_1_plain.png";
+
+
+        assertThrowsBuildBreadStyle(content, name, color, url, profileImgUrl);
+    }
+
+
+    private void assertThrowsBuildBreadStyle(String content, String name, String color, String url, String profileImgUrl) {
+        assertThrows(RuntimeException.class, () -> {
+            BreadStyle.builder()
+                    .content(content)
+                    .name(name)
+                    .color(color)
+                    .contentImgUrl(url)
+                    .profileImgUrl(profileImgUrl)
+                    .build();
+        });
+    }
+}


### PR DESCRIPTION
### 요약
최초등록자'닉네임'pick으로 빵집 카드 정보와 동일하게 수정

### 작업내역

- 최애빵 스타일 별  색상 추가  
- ImageUrl  ValueObject 생성
- 최애빵 스타일 관련 테스트 코드 추가
- 최애빵 스타일을 조회하는 UserResponseDto 관련 수정

@younger-k 연하님도 리스트의 Pick 색상 관련해서 search API 결과의 breadStyleColor 프로퍼티를 통해
 적용하실 수 있으십니다.

### 작성자의 고민

최애빵 스타일은 잘 변하지 않는 값 들이니 반복되는 조회에서 JPA 2차캐싱 까지 넘어갈 수 있도록 처리하면 좋겠다는 생각을 했습니다.

