### PR TITLE
design: [약관동의 전문보기][빵집상세화면][메인 리스트 화면] appbar, webview 색 통일, 클릭 시 효과 해제

### DIFF
--- a/breadgood_app/lib/main.dart
+++ b/breadgood_app/lib/main.dart
@@ -20,6 +20,9 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
         fontFamily: 'AppleSDGothicNeo',
+        scaffoldBackgroundColor: Colors.white,
+        highlightColor: Colors.transparent,
+        splashColor: Colors.transparent,
       ),
       defaultTransition: Transition.noTransition,
       getPages: Routes,


### PR DESCRIPTION
### 요약
- 웹뷰와 앱바 백그라운드 컬러 통일
- 앱바 내 뒤로 가기 버튼 클릭 시 회색 동그라미 효과 해제

### 작업내역
- 전체 Scaffold default color white 로 설정(default: gray)
- splash color, highlight color transparent 로 지정

### 작성자의 고민
- 웹뷰 화면에서 앱바 아래에 경계선이 생기는 것으로 보입니다. 제거하려고 했으나 방법을 찾지 못했습니다.