### PR TITLE
design: [빵집 카테고리 선택 화면] 빵집 카테고리 버튼 순서 변경

### DIFF
--- a/breadgood_app/lib/modules/register_bakery/screens/select_bakery_category.dart
+++ b/breadgood_app/lib/modules/register_bakery/screens/select_bakery_category.dart
@@ -343,8 +343,8 @@ class _SelectBakeryCategoryPageState extends State<SelectBakeryCategoryPage> {
           Padding(
             padding: EdgeInsets.fromLTRB(0, 40, 0, 8),
             child:
-              _createBakeryCategoryToggle(snapshot.data[1]),),
-              _createBakeryCategoryToggle(snapshot.data[0]),
+              _createBakeryCategoryToggle(snapshot.data[0]),),
+              _createBakeryCategoryToggle(snapshot.data[1]),
         ]
           );
         } else if (snapshot.hasError) {
@@ -393,11 +393,13 @@ class _SelectBakeryCategoryPageState extends State<SelectBakeryCategoryPage> {
                 children: [
                   Padding(
                     padding: EdgeInsets.fromLTRB(0, 2, 16, 2),
-                    child: Image.network(
-                        // 'asset/images/icon/map/with_bread.png',
-                      category.makerImgUrl,
-                        height: 36,
-                        width: 44),
+                    child: Container(
+                        width: 36,
+                        height: 44,
+                        child: Image.network(
+                          category.makerImgUrl,
+                          fit: BoxFit.scaleDown,
+                        )),
                   ),
                   Text(
                     (category.id == 1)


### PR DESCRIPTION
### 요약
빵집 카테고리 선택 화면에서 빵집 카테고리 버튼 순서 변경 및 아이콘 크기 조정

### 작업내역
- 빵집 카테고리 선택 화면에서 1. 커피&차와 함께 빵을 즐길 수 있는 베이커리 카페, 2. 빵을 전문적으로 파는 일반 베이커리 순으로 나열
- 카테고리 아이콘 사이즈 변경

### 작성자의 고민
단순 디자인 적용건입니다.