### PR TITLE
[UVNX-168] 지역필터 비활성화 기능 제거

### DIFF
--- a/breadgood-server/src/main/resources/static/js/component/bakeryList.jsx
+++ b/breadgood-server/src/main/resources/static/js/component/bakeryList.jsx
@@ -279,7 +279,6 @@ const BakeryList = () => {
           </div>
           <div className="filter-button-wrapper">
             <button
-              disabled={filter.location === selectedLocation}
               type="button"
               className="lo-filter-btn"
               onClick={() => {


### PR DESCRIPTION
### 요약

- AS-IS : 현재 선택된 지역일 경우 필터 버튼이 비활성화

- TO-BE : 현재 선택된 지역일지라도 필터 버튼 활성화
 
### 작업내역

- button Element의 disabled 속성 제거

### 작성자의 고민

- 없습니다!