### PR TITLE
fix: 빵집 검색 오류 수정

### DIFF
--- a/breadgood_app/lib/modules/register_bakery/model/bakery_data.dart
+++ b/breadgood_app/lib/modules/register_bakery/model/bakery_data.dart
@@ -62,6 +62,10 @@ class SearchData {
       mapy: json['mapy'].toString(),
     );
   }
+
+  getCity() {
+    return this.address.substring(0, 2);
+  }
 }
 
 class BakeryMapData {

--- a/breadgood_app/lib/modules/register_bakery_renewal/model/kakao_bakery_data.dart
+++ b/breadgood_app/lib/modules/register_bakery_renewal/model/kakao_bakery_data.dart
@@ -1,0 +1,36 @@
+class KakaoBakeryData {
+  KakaoBakeryData.fromJson(dynamic json) {
+    addressName = json['address_name'];
+    categoryName = json['category_name'];
+    placeName = json['place_name'];
+    placeUrl = json['place_url'];
+    roadAddressName = json['road_address_name'];
+    x = json['x'];
+    y = json['y'];
+  }
+
+  String addressName;
+  String categoryName;
+  String placeName;
+  String placeUrl;
+  String roadAddressName;
+  String x;
+  String y;
+}
+
+/*
+    {
+      "address_name": "서울 성동구 성수동1가 13-441",
+      "category_group_code": "FD6",
+      "category_group_name": "음식점",
+      "category_name": "음식점 > 간식 > 제과,베이커리",
+      "distance": "",
+      "id": "27245239",
+      "phone": "070-7806-1225",
+      "place_name": "본노엘",
+      "place_url": "http://place.map.kakao.com/27245239",
+      "road_address_name": "서울 성동구 상원길 64",
+      "x": "127.04800900705958",
+      "y": "37.54974607971914"
+    },
+ */

--- a/breadgood_app/lib/modules/register_bakery_renewal/model/kakao_search_data.dart
+++ b/breadgood_app/lib/modules/register_bakery_renewal/model/kakao_search_data.dart
@@ -1,36 +1,8 @@
+import 'package:breadgood_app/modules/register_bakery/model/bakery_data.dart';
+
 class KakaoSearchData {
-  KakaoSearchData.fromJson(dynamic json) {
-    addressName = json['address_name'];
-    categoryName = json['category_name'];
-    placeName = json['place_name'];
-    placeUrl = json['place_url'];
-    roadAddressName = json['road_address_name'];
-    x = json['x'];
-    y = json['y'];
-  }
+  List<SearchData> searchData;
+  bool isEnd;
 
-  String addressName;
-  String categoryName;
-  String placeName;
-  String placeUrl;
-  String roadAddressName;
-  String x;
-  String y;
+  KakaoSearchData(this.searchData, this.isEnd);
 }
-
-/*
-    {
-      "address_name": "서울 성동구 성수동1가 13-441",
-      "category_group_code": "FD6",
-      "category_group_name": "음식점",
-      "category_name": "음식점 > 간식 > 제과,베이커리",
-      "distance": "",
-      "id": "27245239",
-      "phone": "070-7806-1225",
-      "place_name": "본노엘",
-      "place_url": "http://place.map.kakao.com/27245239",
-      "road_address_name": "서울 성동구 상원길 64",
-      "x": "127.04800900705958",
-      "y": "37.54974607971914"
-    },
- */

--- a/breadgood_app/lib/modules/register_bakery_renewal/register_bakery_renewal.dart
+++ b/breadgood_app/lib/modules/register_bakery_renewal/register_bakery_renewal.dart
@@ -151,17 +151,21 @@ class _RegisterBakeryRenewalState extends State<RegisterBakeryRenewal> {
               padding: EdgeInsets.only(bottom: 16),
               child: BakeryCard(selectedBakery: item));
         }).toList(),
-        TextButton(
-          onPressed: () {
-            Navigator.push(
-                context,
-                MaterialPageRoute(
-                    builder: (cont) => SearchMore(
-                        searchWord: controller.searchController.text)));
-          },
-          child: Text('빵집 더 보기'),
-        )
+        if(!controller.isEnd) _moreButton(),
       ]),
+    );
+  }
+
+  Widget _moreButton() {
+    return TextButton(
+      onPressed: () {
+        Navigator.push(
+            context,
+            MaterialPageRoute(
+                builder: (cont) => SearchMore(
+                    searchWord: controller.searchController.text)));
+        },
+      child: Text('빵집 더 보기'),
     );
   }
 

--- a/breadgood_app/lib/modules/register_bakery_renewal/register_bakery_renewal_controller.dart
+++ b/breadgood_app/lib/modules/register_bakery_renewal/register_bakery_renewal_controller.dart
@@ -1,5 +1,6 @@
 import 'package:breadgood_app/interface/kakao_place_search_interface.dart';
 import 'package:breadgood_app/modules/register_bakery/model/bakery_data.dart';
+import 'package:breadgood_app/modules/register_bakery_renewal/model/kakao_search_data.dart';
 import 'package:flutter/material.dart';
 
 class RegisterBakeryRenewalController {
@@ -10,9 +11,35 @@ class RegisterBakeryRenewalController {
   
   TextEditingController searchController = TextEditingController();
   List<SearchData> searchList = [];
+  bool isEnd;
+
+  final String seoul = '서울';
 
   Future<void> onSearch() async {
-    searchList = await KakaoPlaceSearchInterface.get(searchController.text, 1);
+    initialize();
+
+    int page = 1;
+    String keyword = searchController.text;
+
+    while(searchList.length < 5 && !isEnd) {
+      KakaoSearchData result = await KakaoPlaceSearchInterface.get(keyword, page);
+
+      for(SearchData data in result.searchData) {
+        var city = data.getCity();
+        if (city == seoul && searchList.length < 5) {
+          searchList.add(data);
+        }
+      }
+
+      isEnd = result.isEnd;
+      page = page + 1;
+    }
+
     refresh();
+  }
+
+  initialize() {
+    searchList = [];
+    isEnd = false;
   }
 }

--- a/breadgood_app/lib/modules/register_bakery_renewal/search_more/search_more.dart
+++ b/breadgood_app/lib/modules/register_bakery_renewal/search_more/search_more.dart
@@ -77,14 +77,18 @@ class _SearchMoreState extends State<SearchMore> {
                 padding: EdgeInsets.only(bottom: 16),
                 child: BakeryCard(selectedBakery: item));
           }).toList(),
-          TextButton(
-            onPressed: () {
-              controller.onSeeMoreButtonClicked();
-            },
-            child: Text('빵집 더 보기'),
-          )
+          if(!controller.isEnd || controller.tempList.isNotEmpty) _moreButton(),
         ]
       ),
+    );
+  }
+
+  Widget _moreButton() {
+    return TextButton(
+      onPressed: () {
+        controller.onSeeMoreButtonClicked();
+      },
+      child: Text('빵집 더 보기'),
     );
   }
 

--- a/breadgood_app/lib/modules/register_bakery_renewal/search_more/search_more_controller.dart
+++ b/breadgood_app/lib/modules/register_bakery_renewal/search_more/search_more_controller.dart
@@ -1,6 +1,7 @@
 import 'package:breadgood_app/interface/kakao_place_search_interface.dart';
 import 'package:breadgood_app/modules/register_bakery/model/bakery_data.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 
 class SearchMoreController {
   SearchMoreController(this.context, this.refresh, this.searchWord) {
@@ -13,9 +14,36 @@ class SearchMoreController {
   String searchWord;
   int page = 1;
   List<SearchData> searchList = [];
+  List<SearchData> tempList = [];
+  bool isEnd = false;
+
+  final String seoul = '서울';
 
   Future<void> onSeeMoreButtonClicked() async {
-    searchList.addAll(await KakaoPlaceSearchInterface.get(searchWord, page++));
+    List<SearchData> addList = [];
+    addList.addAll(tempList);
+    tempList = [];
+
+    while(addList.length < 5 && !isEnd) {
+      var result = await KakaoPlaceSearchInterface.get(searchWord, page);
+
+      for(SearchData data in result.searchData) {
+        var city = data.getCity();
+        print(city);
+        if (city == seoul) {  // 서울일 경우에만 노출
+          if (addList.length < 5) {
+            addList.add(data);
+          } else {
+            tempList.add(data);
+          }
+        }
+      }
+
+      isEnd = result.isEnd;
+      page = page + 1;
+    }
+
+    searchList.addAll(addList);
     refresh();
   }
 }


### PR DESCRIPTION
### 요약
빵집 검색 버그 수정

### 작업내역
1. 서울 지역만 다섯개씩 필터링 되도록 수정
 - 카카오 API에서 지역필터를 따로 제공하지 않으므로 직접 코드 상에서 주소에 "서울" 이 들어가는 경우를 필터링 하도록 작업하였습니다.
 - 검색 시에 다섯개씩 노출이 되어야 하므로 배열에 지역 필터링된 결과가 다섯개가 될 때 까지 API 호출을 진행합니다.
 
2. 마지막 페이지에서 더보기 버튼 노출이 되지 않도록 수정

### 작성자의 고민
 카카오 API 호출이 잦을 것 같은데 이에 대해 문제는 없을지 고민입니다..
